### PR TITLE
Native WebSocket Support for .Net Standard

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "TwitchLib.WebSocket"]
+	path = TwitchLib.WebSocket
+	url = https://github.com/TwitchLib/TwitchLib.WebSocket

--- a/TwitchLib.PubSub.sln
+++ b/TwitchLib.PubSub.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 15.0.27004.2005
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TwitchLib.PubSub", "TwitchLib.PubSub\TwitchLib.PubSub.csproj", "{BF806D39-66B7-41CF-9406-5383B22D5677}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TwitchLib.WebSocket", "..\TwitchLib.WebSocket\TwitchLib.WebSocket.csproj", "{EEDB18AE-526F-4A80-AC2B-E98ABB9537FE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TwitchLib.WebSocket", "TwitchLib.WebSocket\TwitchLib.WebSocket.csproj", "{7AE87751-6442-4435-A8A4-5167C7712FF0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -17,10 +17,10 @@ Global
 		{BF806D39-66B7-41CF-9406-5383B22D5677}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BF806D39-66B7-41CF-9406-5383B22D5677}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BF806D39-66B7-41CF-9406-5383B22D5677}.Release|Any CPU.Build.0 = Release|Any CPU
-		{EEDB18AE-526F-4A80-AC2B-E98ABB9537FE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{EEDB18AE-526F-4A80-AC2B-E98ABB9537FE}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EEDB18AE-526F-4A80-AC2B-E98ABB9537FE}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{EEDB18AE-526F-4A80-AC2B-E98ABB9537FE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7AE87751-6442-4435-A8A4-5167C7712FF0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7AE87751-6442-4435-A8A4-5167C7712FF0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7AE87751-6442-4435-A8A4-5167C7712FF0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7AE87751-6442-4435-A8A4-5167C7712FF0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/TwitchLib.PubSub.sln
+++ b/TwitchLib.PubSub.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 15.0.27004.2005
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TwitchLib.PubSub", "TwitchLib.PubSub\TwitchLib.PubSub.csproj", "{BF806D39-66B7-41CF-9406-5383B22D5677}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TwitchLib.Websockets", "..\TwitchLib.Websockets\TwitchLib.Websockets.csproj", "{EEDB18AE-526F-4A80-AC2B-E98ABB9537FE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TwitchLib.WebSocket", "..\TwitchLib.WebSocket\TwitchLib.WebSocket.csproj", "{EEDB18AE-526F-4A80-AC2B-E98ABB9537FE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/TwitchLib.PubSub.sln
+++ b/TwitchLib.PubSub.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 15.0.27004.2005
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TwitchLib.PubSub", "TwitchLib.PubSub\TwitchLib.PubSub.csproj", "{BF806D39-66B7-41CF-9406-5383B22D5677}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TwitchLib.Websockets", "..\TwitchLib.Websockets\TwitchLib.Websockets.csproj", "{EEDB18AE-526F-4A80-AC2B-E98ABB9537FE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{BF806D39-66B7-41CF-9406-5383B22D5677}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BF806D39-66B7-41CF-9406-5383B22D5677}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BF806D39-66B7-41CF-9406-5383B22D5677}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EEDB18AE-526F-4A80-AC2B-E98ABB9537FE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EEDB18AE-526F-4A80-AC2B-E98ABB9537FE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EEDB18AE-526F-4A80-AC2B-E98ABB9537FE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EEDB18AE-526F-4A80-AC2B-E98ABB9537FE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/TwitchLib.PubSub/TwitchLib.PubSub.csproj
+++ b/TwitchLib.PubSub/TwitchLib.PubSub.csproj
@@ -38,7 +38,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
-    <ProjectReference Include="..\..\TwitchLib.Websockets\TwitchLib.Websockets.csproj" />
+    <ProjectReference Include="..\..\TwitchLib.WebSocket\TwitchLib.WebSocket.csproj" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">

--- a/TwitchLib.PubSub/TwitchLib.PubSub.csproj
+++ b/TwitchLib.PubSub/TwitchLib.PubSub.csproj
@@ -23,7 +23,6 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
-    <PackageReference Include="WebSocket4Net" Version="0.15.2" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net452'">
@@ -33,6 +32,14 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
     <DefineConstants>NETSTANDARD</DefineConstants>
   </PropertyGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452'">
+    <PackageReference Include="WebSocket4Net" Version="0.15.2" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
+    <ProjectReference Include="..\..\TwitchLib.Websockets\TwitchLib.Websockets.csproj" />
+  </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>

--- a/TwitchLib.PubSub/TwitchLib.PubSub.csproj
+++ b/TwitchLib.PubSub/TwitchLib.PubSub.csproj
@@ -23,6 +23,8 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
-    <ProjectReference Include="..\..\TwitchLib.WebSocket\TwitchLib.WebSocket.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\TwitchLib.WebSocket\TwitchLib.WebSocket.csproj" />
   </ItemGroup>
 </Project>

--- a/TwitchLib.PubSub/TwitchLib.PubSub.csproj
+++ b/TwitchLib.PubSub/TwitchLib.PubSub.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>TwitchLib.PubSub</PackageId>
     <Version>2.0.3</Version>
     <Description>PubSub component of TwitchLib. This component allows you to access Twitch's PubSub event system and subscribe/unsubscribe from topics.</Description>
@@ -22,27 +22,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
-  </ItemGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net452'">
-    <DefineConstants>NET452</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
-    <DefineConstants>NETSTANDARD</DefineConstants>
-  </PropertyGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452'">
-    <PackageReference Include="WebSocket4Net" Version="0.15.2" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
     <ProjectReference Include="..\..\TwitchLib.WebSocket\TwitchLib.WebSocket.csproj" />
   </ItemGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <WarningsAsErrors>NU1605</WarningsAsErrors>
-  </PropertyGroup>
 </Project>

--- a/TwitchLib.PubSub/TwitchPubSub.cs
+++ b/TwitchLib.PubSub/TwitchPubSub.cs
@@ -15,7 +15,7 @@ using SuperSocket.ClientEngine;
 using SuperSocket.ClientEngine.Proxy;
 using System.Net;
 #elif NETSTANDARD
-using TwitchLib.Websockets;
+using TwitchLib.WebSocket;
 #endif
 
 namespace TwitchLib.PubSub
@@ -26,7 +26,7 @@ namespace TwitchLib.PubSub
 #if NET452
         private readonly WebSocket _socket;
 #elif NETSTANDARD
-        private readonly WebsocketClient _socket;
+        private readonly WebSocketClient _socket;
 #endif
         private readonly List<PreviousRequest> _previousRequests = new List<PreviousRequest>();
         private readonly ILogger<TwitchPubSub> _logger;
@@ -115,8 +115,8 @@ namespace TwitchLib.PubSub
         {
             _logger = logger;
 
-            var options = new WebsocketClientOptions() { ClientType = Websockets.Enums.ClientType.PubSub };
-            _socket = new WebsocketClient(options);
+            var options = new WebSocketClientOptions() { ClientType = WebSocket.Enums.ClientType.PubSub };
+            _socket = new WebSocketClient(options);
 
             _socket.OnConnected += Socket_OnConnected;
             _socket.OnError += OnError;
@@ -138,13 +138,13 @@ namespace TwitchLib.PubSub
             ParseMessage(e.Message);
         }
 #elif NETSTANDARD
-        private void OnError(object sender, Websockets.Events.OnErrorEventArgs e)
+        private void OnError(object sender, WebSocket.Events.OnErrorEventArgs e)
         {
             _logger?.LogError($"Error in PubSub Websocket connection occured! Exception: {e.Exception}");
             OnPubSubServiceError?.Invoke(this, new OnPubSubServiceErrorArgs { Exception = e.Exception });
         }
 
-        private void OnMessage(object sender, Websockets.Events.OnMessageEventArgs e)
+        private void OnMessage(object sender, WebSocket.Events.OnMessageEventArgs e)
         {
             _logger?.LogDebug($"Received Websocket Message: {e.Message}");
             ParseMessage(e.Message);


### PR DESCRIPTION
Replaces WebSocket4Net in NETSTANDARD only, with the native Sub Module (PR for submodule only will be pushed in a few mins to the TwitchLib master Repo).