### PR TITLE
Adds an OnLog event for quick debugging

### DIFF
--- a/TwitchLib.PubSub/Events/OnLogArgs.cs
+++ b/TwitchLib.PubSub/Events/OnLogArgs.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.PubSub.Events
+{
+    public class OnLogArgs
+    {
+        /// <summary>Property representing data received from Twitch</summary>
+        public string Data;
+    }
+}

--- a/TwitchLib.PubSub/Interfaces/ITwitchPubSub.cs
+++ b/TwitchLib.PubSub/Interfaces/ITwitchPubSub.cs
@@ -27,6 +27,7 @@ namespace TwitchLib.PubSub.Interfaces
         event EventHandler<OnUntimeoutArgs> OnUntimeout;
         event EventHandler<OnViewCountArgs> OnViewCount;
         event EventHandler<OnWhisperArgs> OnWhisper;
+        event EventHandler<OnLogArgs> OnLog;
 
         void Connect();
         void Disconnect();

--- a/TwitchLib.PubSub/TwitchPubSub.cs
+++ b/TwitchLib.PubSub/TwitchPubSub.cs
@@ -74,6 +74,8 @@ namespace TwitchLib.PubSub
         public event EventHandler<OnChannelExtensionBroadcastArgs> OnChannelExtensionBroadcast;
         /// <summary>Fires when PubSub receives notice when a user follows the designated channel.</summary>
         public event EventHandler<OnFollowArgs> OnFollow;
+        /// <summary>Fires when PubSub receives any data from Twitch</summary>
+        public event EventHandler<OnLogArgs> OnLog;
         #endregion
 
         /// <summary>
@@ -102,6 +104,7 @@ namespace TwitchLib.PubSub
         private void OnMessage(object sender, Communication.Events.OnMessageEventArgs e)
         {
             _logger?.LogDebug($"Received Websocket Message: {e.Message}");
+            OnLog?.Invoke(this, new OnLogArgs { Data = e.Message });
             ParseMessage(e.Message);
         }
 


### PR DESCRIPTION
OnLog exists in the Client and allows for easy on the fly debugging. This PR adds a similar event to the PubSub client.