### PR TITLE
Add OnMessageDeleted moderator action

### DIFF
--- a/TwitchLib.PubSub/Events/OnMessageDeletedArgs.cs
+++ b/TwitchLib.PubSub/Events/OnMessageDeletedArgs.cs
@@ -1,0 +1,24 @@
+﻿namespace TwitchLib.PubSub.Events
+{
+    /// <summary>OnMessageDeleted event arguments class.</summary>
+    public class OnMessageDeletedArgs
+    {
+        /// <summary>Name of the user whose message was deleted</summary>
+        public string TargetUser;
+
+        /// <summary>ID of the user whose message was deleted</summary>
+        public string TargetUserId;
+
+        /// <summary>Name of the moderator who deleted the message</summary>
+        public string DeletedBy;
+
+        /// <summary>ID of the moderator who deleted the message</summary>
+        public string DeletedByUserId;
+
+        /// <summary>The message that was deleted</summary>
+        public string Message;
+
+        /// <summary>ID of the message that was deleted</summary>
+        public string MessageId;
+    }
+}

--- a/TwitchLib.PubSub/TwitchPubSub.cs
+++ b/TwitchLib.PubSub/TwitchPubSub.cs
@@ -36,6 +36,8 @@ namespace TwitchLib.PubSub
         public event EventHandler<OnTimeoutArgs> OnTimeout;
         /// <summary>Fires when PubSub receives notice a viewer gets banned.</summary>
         public event EventHandler<OnBanArgs> OnBan;
+        /// <summary>Fires when PubSub receives notice a message was deleted.</summary>
+        public event EventHandler<OnMessageDeletedArgs> OnMessageDeleted;
         /// <summary>Fires when PubSub receives notice a viewer gets unbanned.</summary>
         public event EventHandler<OnUnbanArgs> OnUnban;
         /// <summary>Fires when PubSub receives notice a viewer gets a timeout removed.</summary>
@@ -186,6 +188,9 @@ namespace TwitchLib.PubSub
                                     if (cma.Args.Count > 1)
                                         reason = cma.Args[1];
                                     OnBan?.Invoke(this, new OnBanArgs { BannedBy = cma.CreatedBy, BannedByUserId = cma.CreatedByUserId, BannedUserId = cma.TargetUserId, BanReason = reason, BannedUser = cma.Args[0] });
+                                    return;
+                                case "delete":
+                                    OnMessageDeleted?.Invoke(this, new OnMessageDeletedArgs { DeletedBy = cma.CreatedBy, DeletedByUserId = cma.CreatedByUserId, TargetUserId = cma.TargetUserId, TargetUser = cma.Args[0], Message = cma.Args[1], MessageId = cma.Args[2] });
                                     return;
                                 case "unban":
                                     OnUnban?.Invoke(this, new OnUnbanArgs { UnbannedBy = cma.CreatedBy, UnbannedByUserId = cma.CreatedByUserId, UnbannedUserId = cma.TargetUserId, UnbannedUser = cma.Args[0] });


### PR DESCRIPTION
This adds the PubSub event for mods deleting messages. For reference, an example parsed version of the data payload is below.

```json
{
  "data": {
    "type": "chat_login_moderation",
    "moderation_action": "delete",
    "args": [
      "alexanderthegreat200",
      "VoteYea VoteYea",
      "a5092c19-1d59-4480-8a32-c94794579272"
    ],
    "created_by": "pokelec",
    "created_by_user_id": "109743169",
    "msg_id": "",
    "target_user_id": "89653350"
  }
}
```