### PR TITLE
Channel id support

### DIFF
--- a/TwitchLib.PubSub/Events/OnBanArgs.cs
+++ b/TwitchLib.PubSub/Events/OnBanArgs.cs
@@ -25,5 +25,10 @@
         /// Property representing the user id of the moderator that banned the user.
         /// </summary>
         public string BannedByUserId;
+
+        /// <summary>
+        /// The channel ID the event came from
+        /// </summary>
+        public string ChannelId;
     }
 }

--- a/TwitchLib.PubSub/Events/OnChannelExtensionBroadcastArgs.cs
+++ b/TwitchLib.PubSub/Events/OnChannelExtensionBroadcastArgs.cs
@@ -11,5 +11,9 @@ namespace TwitchLib.PubSub.Events
         /// Property containing the payload send to the specified extension on the specified channel.
         /// </summary>
         public List<string> Messages;
+        /// <summary>
+        /// The channel ID the event came from
+        /// </summary>
+        public string ChannelId;
     }
 }

--- a/TwitchLib.PubSub/Events/OnChannelSubscriptionArgs.cs
+++ b/TwitchLib.PubSub/Events/OnChannelSubscriptionArgs.cs
@@ -11,5 +11,10 @@ namespace TwitchLib.PubSub.Events
         /// The subscription
         /// </summary>
         public ChannelSubscription Subscription;
+
+        /// <summary>
+        /// The channel ID the event came from
+        /// </summary>
+        public string ChannelId;
     }
 }

--- a/TwitchLib.PubSub/Events/OnClearArgs.cs
+++ b/TwitchLib.PubSub/Events/OnClearArgs.cs
@@ -9,5 +9,9 @@
         /// Property representing username of moderator who cleared chat.
         /// </summary>
         public string Moderator;
+        /// <summary>
+        /// The channel ID the event came from
+        /// </summary>
+        public string ChannelId;
     }
 }

--- a/TwitchLib.PubSub/Events/OnEmoteOnlyArgs.cs
+++ b/TwitchLib.PubSub/Events/OnEmoteOnlyArgs.cs
@@ -9,5 +9,9 @@
         /// Property representing moderator who issued moderator only command.
         /// </summary>
         public string Moderator;
+        /// <summary>
+        /// The channel ID the event came from
+        /// </summary>
+        public string ChannelId;
     }
 }

--- a/TwitchLib.PubSub/Events/OnEmoteOnlyOffArgs.cs
+++ b/TwitchLib.PubSub/Events/OnEmoteOnlyOffArgs.cs
@@ -9,5 +9,9 @@
         /// Property representing moderator who issued command.
         /// </summary>
         public string Moderator;
+        /// <summary>
+        /// The channel ID the event came from
+        /// </summary>
+        public string ChannelId;
     }
 }

--- a/TwitchLib.PubSub/Events/OnHostArgs.cs
+++ b/TwitchLib.PubSub/Events/OnHostArgs.cs
@@ -13,5 +13,9 @@
         /// Property representing hosted channel.
         /// </summary>
         public string HostedChannel;
+        /// <summary>
+        /// The channel ID the event came from
+        /// </summary>
+        public string ChannelId;
     }
 }

--- a/TwitchLib.PubSub/Events/OnMessageDeletedArgs.cs
+++ b/TwitchLib.PubSub/Events/OnMessageDeletedArgs.cs
@@ -34,5 +34,10 @@
         /// ID of the message that was deleted
         /// </summary>
         public string MessageId;
+
+        /// <summary>
+        /// The channel ID the event came from
+        /// </summary>
+        public string ChannelId;
     }
 }

--- a/TwitchLib.PubSub/Events/OnR9kBetaArgs.cs
+++ b/TwitchLib.PubSub/Events/OnR9kBetaArgs.cs
@@ -9,5 +9,9 @@
         /// Property representing moderator that issued command.
         /// </summary>
         public string Moderator;
+        /// <summary>
+        /// The channel ID the event came from
+        /// </summary>
+        public string ChannelId;
     }
 }

--- a/TwitchLib.PubSub/Events/OnR9kBetaOffArgs.cs
+++ b/TwitchLib.PubSub/Events/OnR9kBetaOffArgs.cs
@@ -9,5 +9,9 @@
         /// Property representing moderator that issued command.
         /// </summary>
         public string Moderator;
+        /// <summary>
+        /// The channel ID the event came from
+        /// </summary>
+        public string ChannelId;
     }
 }

--- a/TwitchLib.PubSub/Events/OnSubscribersOnlyArgs.cs
+++ b/TwitchLib.PubSub/Events/OnSubscribersOnlyArgs.cs
@@ -9,5 +9,9 @@
         /// Property representing moderator that issued command.
         /// </summary>
         public string Moderator;
+        /// <summary>
+        /// The channel ID the event came from
+        /// </summary>
+        public string ChannelId;
     }
 }

--- a/TwitchLib.PubSub/Events/OnSubscribersOnlyOff.cs
+++ b/TwitchLib.PubSub/Events/OnSubscribersOnlyOff.cs
@@ -9,5 +9,9 @@
         /// Property representing the moderator that issued the command.
         /// </summary>
         public string Moderator;
+        /// <summary>
+        /// The channel ID the event came from
+        /// </summary>
+        public string ChannelId;
     }
 }

--- a/TwitchLib.PubSub/Events/OnTimeoutArgs.cs
+++ b/TwitchLib.PubSub/Events/OnTimeoutArgs.cs
@@ -31,5 +31,10 @@ namespace TwitchLib.PubSub.Events
         /// Property representing the moderator that issued the command's user id.
         /// </summary>
         public string TimedoutById;
+
+        /// <summary>
+        /// The channel ID the event came from
+        /// </summary>
+        public string ChannelId;
     }
 }

--- a/TwitchLib.PubSub/Events/OnUnbanArgs.cs
+++ b/TwitchLib.PubSub/Events/OnUnbanArgs.cs
@@ -21,5 +21,9 @@
         /// Userid of the unbanned user.
         /// </summary>
         public string UnbannedByUserId;
+        /// <summary>
+        /// The channel ID the event came from
+        /// </summary>
+        public string ChannelId;
     }
 }

--- a/TwitchLib.PubSub/Events/OnUntimeoutArgs.cs
+++ b/TwitchLib.PubSub/Events/OnUntimeoutArgs.cs
@@ -21,5 +21,9 @@
         /// Moderator user id that issued untimeout command.
         /// </summary>
         public string UntimeoutedByUserId;
+        /// <summary>
+        /// The channel ID the event came from
+        /// </summary>
+        public string ChannelId;
     }
 }

--- a/TwitchLib.PubSub/Events/OnWhisperArgs.cs
+++ b/TwitchLib.PubSub/Events/OnWhisperArgs.cs
@@ -11,5 +11,10 @@ namespace TwitchLib.PubSub.Events
         /// Property representing the whisper object.
         /// </summary>
         public Whisper Whisper;
+
+        /// <summary>
+        /// The channel ID the event came from
+        /// </summary>
+        public string ChannelId;
     }
 }

--- a/TwitchLib.PubSub/TwitchPubSub.cs
+++ b/TwitchLib.PubSub/TwitchPubSub.cs
@@ -252,7 +252,6 @@ namespace TwitchLib.PubSub
                         {
                             if (string.Equals(request.Nonce, resp.Nonce, StringComparison.CurrentCultureIgnoreCase))
                             {
-                                Console.WriteLine(request.Topic);
                                 OnListenResponse?.Invoke(this, new OnListenResponseArgs { Response = resp, Topic = request.Topic, Successful = resp.Successful });
                             }
                         }


### PR DESCRIPTION
This adds `ChannelId` support to models that don't already have channel id.
Because: 
- not all payloads for topics have channel id in them
- topics are inconsistent in their format

This uses a dictionary that associates a given topic with a given channel. This way we can be certain the channel id is what the user states it is, at time of calling `ListenToX` method. This also doesn't require parsing the topic to extract the channel id, which gets messy when all topics have different formatting.