### PR TITLE
Update ChannelSubscription

### DIFF
--- a/TwitchLib.PubSub/Models/Responses/Messages/ChannelSubscription.cs
+++ b/TwitchLib.PubSub/Models/Responses/Messages/ChannelSubscription.cs
@@ -70,7 +70,17 @@ namespace TwitchLib.PubSub.Models.Responses.Messages
         /// Gets or sets the months.
         /// </summary>
         /// <value>The months.</value>
-        public int Months { get; }
+        public int? Months { get; }
+        /// <summary>
+        /// Gets or sets the number of cumulative months.
+        /// </summary>
+        /// <value>The cumulative months.</value>
+        public int? CumulativeMonths { get; }
+        /// <summary>
+        /// Gets or sets the number of streak months.
+        /// </summary>
+        /// <value>The streak months.</value>
+        public int? StreakMonths { get; }
         /// <summary>
         /// Gets or sets the context.
         /// </summary>
@@ -117,9 +127,28 @@ namespace TwitchLib.PubSub.Models.Responses.Messages
                     throw new ArgumentOutOfRangeException();
             }
             SubscriptionPlanName = message.SelectToken("sub_plan_name")?.ToString();
-            Months = int.Parse(message.SelectToken("months").ToString());
             SubMessage = new SubMessage(message.SelectToken("sub_message"));
             Context = message.SelectToken("context")?.ToString();
+
+            var monthsToken = message.SelectToken("months");
+            if (monthsToken != null)
+            {
+                Months = int.Parse(monthsToken.ToString());
+            }
+
+            // these properties are hyphenated unlike all others
+            var cumulativeMonthsToken = message.SelectToken("cumulative-months");
+            var streakMonthsToken = message.SelectToken("streak-months");
+
+            if (cumulativeMonthsToken != null)
+            {
+                CumulativeMonths = int.Parse(cumulativeMonthsToken.ToString());
+            }
+
+            if (streakMonthsToken != null)
+            {
+                StreakMonths = int.Parse(streakMonthsToken.ToString());
+            }
         }
     }
 }


### PR DESCRIPTION
This adds the new `cumulative-months` and `streak-months` properties to `ChannelSubscription`. They are hyphenated, not snake_case like everything else. (That's how it is in the docs and I also verified manually.)

`cumulative-months` and `streak-months` are used only for regular subs/resubs, but the old `months` field is still used for gifts and anon gifts. I figure `int?` is the best way to handle that but I'm not sure, let me know. I verified that manually as well, it's not an inconsistency with the docs.