### PR TITLE
Nicklarsen/general cleanup

### DIFF
--- a/TwitchLib.PubSub/TwitchPubSub.cs
+++ b/TwitchLib.PubSub/TwitchPubSub.cs
@@ -142,14 +142,16 @@ namespace TwitchLib.PubSub
                     var resp = new Models.Responses.Response(message);
                     if (_previousRequests.Count != 0)
                     {
+                        bool handled = false;
                         foreach (var request in _previousRequests)
                         {
                             if (string.Equals(request.Nonce, resp.Nonce, StringComparison.CurrentCulture))
                             {
                                 OnListenResponse?.Invoke(this, new OnListenResponseArgs { Response = resp, Topic = request.Topic, Successful = resp.Successful });
+                                handled = true;
                             }
                         }
-                        return;
+                        if (handled) return;
                     }
                     break;
                 case "message":
@@ -222,6 +224,7 @@ namespace TwitchLib.PubSub
                             break;
                         case "channel-bits-events-v1":
                             if (msg.MessageData is ChannelBitsEvents cbe)
+                            {
                                 OnBitsReceived?.Invoke(this, new OnBitsReceivedArgs
                                 {
                                     BitsUsed = cbe.BitsUsed,
@@ -234,9 +237,12 @@ namespace TwitchLib.PubSub
                                     UserId = cbe.UserId,
                                     Username = cbe.Username
                                 });
-                            return;
+                                return;
+                            }
+                            break;
                         case "channel-commerce-events-v1":
                             if (msg.MessageData is ChannelCommerceEvents cce)
+                            {
                                 OnChannelCommerceReceived?.Invoke(this, new OnChannelCommerceReceivedArgs
                                 {
 
@@ -251,11 +257,13 @@ namespace TwitchLib.PubSub
                                     SupportsChannel = cce.SupportsChannel,
                                     PurchaseMessage = cce.PurchaseMessage
                                 });
-                            return;
+                                return;
+                            }
+                            break;
                         case "channel-ext-v1":
                             var cEB = msg.MessageData as ChannelExtensionBroadcast;
                             OnChannelExtensionBroadcast?.Invoke(this, new OnChannelExtensionBroadcastArgs { Messages = cEB.Messages });
-                            break;
+                            return;
                         case "video-playback":
                             var vP = msg.MessageData as VideoPlayback;
                             switch (vP?.Type)
@@ -275,7 +283,7 @@ namespace TwitchLib.PubSub
                             var f = msg.MessageData as Following;
                             f.FollowedChannelId = msg.Topic.Split('.')[1];
                             OnFollow?.Invoke(this, new OnFollowArgs { FollowedChannelId = f.FollowedChannelId, DisplayName = f.DisplayName, UserId = f.UserId, Username = f.Username });
-                            break;
+                            return;
                     }
                     break;
             }

--- a/TwitchLib.PubSub/TwitchPubSub.cs
+++ b/TwitchLib.PubSub/TwitchPubSub.cs
@@ -144,7 +144,7 @@ namespace TwitchLib.PubSub
                     {
                         foreach (var request in _previousRequests)
                         {
-                            if (string.Equals(request.Nonce, resp.Nonce, StringComparison.CurrentCultureIgnoreCase))
+                            if (string.Equals(request.Nonce, resp.Nonce, StringComparison.CurrentCulture))
                             {
                                 OnListenResponse?.Invoke(this, new OnListenResponseArgs { Response = resp, Topic = request.Topic, Successful = resp.Successful });
                             }


### PR DESCRIPTION
Hello!  Two changes this time around.

First is that the comparison for nonce values has been made case sensitive.  The nonces generated contain both upper and lowercase values, and the responses come back with matching case.  Comparing case insensitive greatly reduces the overall entropy of the value and can allow invalid responses to pass.

I was testing some stuff and noticed that some requests were printing out despite being handled by my code.  This change updates the message handling logic to only call unaccounted for when no event attempts to fire.