### PR TITLE
multi-tenancy support

### DIFF
--- a/TwitchLib.PubSub/Common/Nonce.cs
+++ b/TwitchLib.PubSub/Common/Nonce.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Text;
+using System.Threading;
+
+namespace TwitchLib.PubSub.Common
+{
+    internal static class Nonce
+    {
+        private static Random seeder = new Random();
+        public static ThreadLocal<Random> random = new ThreadLocal<Random>(CreateRandom);
+        private static Random CreateRandom()
+        {
+            lock(seeder)
+            {
+                return new Random(seeder.Next());
+            }
+        }
+
+        const string characters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+        public static string Generate(int length = 8)
+        {
+            var rand = random.Value;
+            var sb = new StringBuilder(length);
+            for(int i = 0; i < length; i++)
+            {
+                var c = characters[rand.Next(characters.Length)];
+                sb.Append(c);
+            }
+            return sb.ToString();
+        }
+    }
+}

--- a/TwitchLib.PubSub/Events/OnStreamDownArgs.cs
+++ b/TwitchLib.PubSub/Events/OnStreamDownArgs.cs
@@ -5,5 +5,7 @@
     {
         /// <summary>Property representing the server time of event.</summary>
         public string ServerTime;
+        /// <summary>Property representing the channel id that this event relates to.</summary>
+        public string ChannelId;
     }
 }

--- a/TwitchLib.PubSub/Events/OnStreamUpArgs.cs
+++ b/TwitchLib.PubSub/Events/OnStreamUpArgs.cs
@@ -7,5 +7,7 @@
         public string ServerTime;
         /// <summary>Property representing play delay.</summary>
         public int PlayDelay;
+        /// <summary>Property representing the channel id associated with this event.</summary>
+        public string ChannelId;
     }
 }

--- a/TwitchLib.PubSub/Events/OnViewCountArgs.cs
+++ b/TwitchLib.PubSub/Events/OnViewCountArgs.cs
@@ -7,5 +7,7 @@
         public string ServerTime;
         /// <summary>Number of viewers at current time.</summary>
         public int Viewers;
+        /// <summary>The channel id associated with this event.</summary>
+        public string ChannelId;
     }
 }

--- a/TwitchLib.PubSub/TwitchPubSub.cs
+++ b/TwitchLib.PubSub/TwitchPubSub.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Logging;
 using TwitchLib.PubSub.Interfaces;
 using TwitchLib.Communication;
 using TwitchLib.Communication.Models;
+using TwitchLib.PubSub.Common;
 
 namespace TwitchLib.PubSub
 {
@@ -282,13 +283,6 @@ namespace TwitchLib.PubSub
             UnaccountedFor(message);
         }
 
-        private static readonly Random Random = new Random();
-        private static string GenerateNonce()
-        {
-            return new string(Enumerable.Repeat("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789", 8)
-                .Select(s => s[Random.Next(s.Length)]).ToArray());
-        }
-
         private void ListenToTopic(string topic)
         {
             _topicList.Add(topic);
@@ -301,7 +295,7 @@ namespace TwitchLib.PubSub
                 oauth = oauth.Replace("oauth:", "");
             }
 
-            var nonce = GenerateNonce();
+            var nonce = Nonce.Generate();
 
             var topics = new JArray();
             foreach (var val in _topicList)

--- a/TwitchLib.PubSub/TwitchPubSub.cs
+++ b/TwitchLib.PubSub/TwitchPubSub.cs
@@ -259,16 +259,17 @@ namespace TwitchLib.PubSub
                             break;
                         case "video-playback":
                             var vP = msg.MessageData as VideoPlayback;
+                            var channelId = msg.Topic.Split('.')[1];
                             switch (vP?.Type)
                             {
                                 case VideoPlaybackType.StreamDown:
-                                    OnStreamDown?.Invoke(this, new OnStreamDownArgs { ServerTime = vP.ServerTime });
+                                    OnStreamDown?.Invoke(this, new OnStreamDownArgs { ServerTime = vP.ServerTime, ChannelId = channelId });
                                     return;
                                 case VideoPlaybackType.StreamUp:
-                                    OnStreamUp?.Invoke(this, new OnStreamUpArgs { PlayDelay = vP.PlayDelay, ServerTime = vP.ServerTime });
+                                    OnStreamUp?.Invoke(this, new OnStreamUpArgs { PlayDelay = vP.PlayDelay, ServerTime = vP.ServerTime, ChannelId = channelId });
                                     return;
                                 case VideoPlaybackType.ViewCount:
-                                    OnViewCount?.Invoke(this, new OnViewCountArgs { ServerTime = vP.ServerTime, Viewers = vP.Viewers });
+                                    OnViewCount?.Invoke(this, new OnViewCountArgs { ServerTime = vP.ServerTime, Viewers = vP.Viewers, ChannelId = channelId });
                                     return;
                             }
                             break;

--- a/TwitchLib.PubSub/TwitchPubSub.cs
+++ b/TwitchLib.PubSub/TwitchPubSub.cs
@@ -291,10 +291,8 @@ namespace TwitchLib.PubSub
 
         public void SendTopics(string oauth = null, bool unlisten = false)
         {
-            if (oauth != null && oauth.Contains("oauth:"))
-            {
-                oauth = oauth.Replace("oauth:", "");
-            }
+            if (oauth == null) throw new ArgumentException("The 'oauth' parameter is required.  See https://dev.twitch.tv/docs/pubsub/#authentication for more details.", nameof(oauth));
+            if (_topicList.Count == 0) return;
 
             var nonce = Nonce.Generate();
 
@@ -310,14 +308,11 @@ namespace TwitchLib.PubSub
                 new JProperty("nonce", nonce),
                 new JProperty("data",
                     new JObject(
-                        new JProperty("topics", topics)
+                        new JProperty("topics", topics),
+                        new JProperty("auth_token", oauth.Replace("oauth:", ""))
                         )
                     )
                 );
-            if (oauth != null)
-            {
-                ((JObject)jsonData.SelectToken("data")).Add(new JProperty("auth_token", oauth));
-            }
 
             _socket.Send(jsonData.ToString());
 


### PR DESCRIPTION
The api documentation says:

> - Clients can listen on up to 50 topics per connection. Trying to listen on more topics will result in an error message.
> - We recommend that a single client IP address establishes no more than 10 simultaneous connections.

I'm trying to write a web app for my stream team that will watch streams and provided functionality across the whole team.  There are currently about 70 members of my team, of course they are not all streaming simultaneously.  Once members of my team generate an account on my app, it will listen for `StreamUp` events and then subscribe to additional topics until it receives a `StreamDown` event at which point it will unlisten all topics except the video playback topic.  At some point we might want to expand this to support more than just my team.

There are a number of concerns in the current implementation that need to be addressed to support this:

- not all relevant event handlers pass the channel id back, most notably the `StreamUp` and `StreamDown` events, but can be identified by the topic passed back with every message
   - ~`StreamUp`~
   - ~`StreamDown`~
   - ~`ViewCount`~
   - others?
- `_previousRequests` is a memory leak because requests do not get removed
- the collection of `Listen...()` functions do not handle requests from multiple streams simultaneously due to varying oauth values
- ~use of `Random` in the `GenerateNonce` function is not thread safe~

I think the rest can be handled by the app code although one additional nice to have would be each connection tracking which topics it is actively subscribed to since that is going to be a concern of every multi-tenancy app.  This is what I can see on the surface although more stuff might pop up as I work through the details.