### PR TITLE
Fix null ref error and video playback events

### DIFF
--- a/TwitchLib.PubSub/TwitchPubSub.cs
+++ b/TwitchLib.PubSub/TwitchPubSub.cs
@@ -289,7 +289,8 @@ namespace TwitchLib.PubSub
                     break;
                 case "message":
                     var msg = new Models.Responses.Message(message);
-                    var channelId = _topicToChannelId[msg.Topic] ?? "";
+                    _topicToChannelId.TryGetValue(msg.Topic, out var channelId);
+                    channelId = channelId ?? "";
                     switch (msg.Topic.Split('.')[0])
                     {
                         case "channel-subscribe-events-v1":


### PR DESCRIPTION
`ListenToVideoPlayback` doesn't add a value to `_topicToChannelId` because the topic uses channel name, not ID. An exception was being thrown as a result when a video playback message was received. This fixes that and lets video playback events work again.

Fixes TwitchLib/TwitchLib#453.