### PR TITLE
Feature channel reward deleted

### DIFF
--- a/TwitchLib.PubSub/Enums/CommunityPointsType.cs
+++ b/TwitchLib.PubSub/Enums/CommunityPointsType.cs
@@ -16,6 +16,10 @@
         /// <summary>
         /// On custom reward created
         /// </summary>
-        CustomRewardCreated
+        CustomRewardCreated,
+        /// <summary>
+        /// On custom reward deleted
+        /// </summary>
+        CustomRewardDeleted
     }
 }

--- a/TwitchLib.PubSub/Events/OnCustomRewardDeletedArgs.cs
+++ b/TwitchLib.PubSub/Events/OnCustomRewardDeletedArgs.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace TwitchLib.PubSub.Events
+{
+    /// <inheritdoc />
+    /// <summary>
+    /// Class representing arguments of custom reward deleted event.
+    /// </summary>
+    public class OnCustomRewardDeletedArgs
+    {
+        /// <summary>
+        /// Property representing server time stamp
+        /// </summary>
+        public DateTime TimeStamp;
+        /// <summary>
+        /// The channel ID the event came from
+        /// </summary>
+        public string ChannelId;
+        /// <summary>
+        /// Property representing the id of the deleted reward
+        /// </summary>
+        public Guid RewardId;
+        /// <summary>
+        /// Property representing title of the deleted reward
+        /// </summary>
+        public string RewardTitle;
+        /// <summary>
+        /// Property representing prompt of the deleted reward
+        /// </summary>
+        public string RewardPrompt;
+    }
+}

--- a/TwitchLib.PubSub/Interfaces/ITwitchPubSub.cs
+++ b/TwitchLib.PubSub/Interfaces/ITwitchPubSub.cs
@@ -113,11 +113,19 @@ namespace TwitchLib.PubSub.Interfaces
         /// </summary>
         event EventHandler<OnWhisperArgs> OnWhisper;
         /// <summary>
-        /// Occurs when [on custom reward updated].
-        /// </summary>
+        /// Occurs when [on reward created]
+        ///</summary>
+        event EventHandler<OnCustomRewardCreatedArgs> OnCustomRewardCreated;
+        /// <summary>
+        /// Occurs when [on reward updated]
+        ///</summary>
         event EventHandler<OnCustomRewardUpdatedArgs> OnCustomRewardUpdated;
         /// <summary>
-        /// Occurs when [on reward redeemed].
+        /// Occurs when [on reward deleted]
+        /// </summary>
+        event EventHandler<OnCustomRewardDeletedArgs> OnCustomRewardDeleted;
+        /// <summary>
+        /// Occurs when [on reward redeemed]
         /// </summary>
         event EventHandler<OnRewardRedeemedArgs> OnRewardRedeemed;
         /// <summary>

--- a/TwitchLib.PubSub/Models/Responses/Messages/CommunityPointsChannel.cs
+++ b/TwitchLib.PubSub/Models/Responses/Messages/CommunityPointsChannel.cs
@@ -86,6 +86,9 @@ namespace TwitchLib.PubSub.Models.Responses.Messages
                 case "custom-reward-updated":
                     Type = CommunityPointsChannelType.CustomRewardUpdated;
                     break;
+                case "custom-reward-deleted":
+                    Type = CommunityPointsChannelType.CustomRewardDeleted;
+                    break;
             }
 
             TimeStamp = DateTime.Parse(json.SelectToken("data.timestamp").ToString());
@@ -116,6 +119,12 @@ namespace TwitchLib.PubSub.Models.Responses.Messages
                     RewardTitle = json.SelectToken("data.new_reward.title").ToString();
                     RewardPrompt = json.SelectToken("data.new_reward.prompt").ToString();
                     RewardCost = int.Parse(json.SelectToken("data.new_reward.cost").ToString());
+                    break;
+                case CommunityPointsChannelType.CustomRewardDeleted:
+                    ChannelId = json.SelectToken("data.deleted_reward.channel_id").ToString();
+                    RewardId = Guid.Parse(json.SelectToken("data.deleted_reward.id").ToString());
+                    RewardTitle = json.SelectToken("data.deleted_reward.title").ToString();
+                    RewardPrompt = json.SelectToken("data.deleted_reward.prompt").ToString();
                     break;
             }
         }

--- a/TwitchLib.PubSub/TwitchPubSub.cs
+++ b/TwitchLib.PubSub/TwitchPubSub.cs
@@ -187,6 +187,12 @@ namespace TwitchLib.PubSub
         /// Fires when pubsub receives notice when a custom reward has been changed on the specified channel.
         ///</summary>
         public event EventHandler<OnCustomRewardUpdatedArgs> OnCustomRewardUpdated;
+
+        /// <inheritdoc />
+        /// <summary>
+        /// Fires when pubsub receives notice when a reward has been deleted on the specified channel.</summary>
+        /// </summary>
+        public event EventHandler<OnCustomRewardDeletedArgs> OnCustomRewardDeleted;
         /// <inheritdoc />
         /// <summary>
         /// Fires when pubsub receives notice when a reward has been redeemed on the specified channel.</summary>
@@ -462,6 +468,9 @@ namespace TwitchLib.PubSub
                                     return;
                                 case CommunityPointsChannelType.CustomRewardCreated:
                                     OnCustomRewardCreated?.Invoke(this, new OnCustomRewardCreatedArgs { TimeStamp = cpc.TimeStamp, ChannelId = cpc.ChannelId, RewardId = cpc.RewardId, RewardTitle = cpc.RewardTitle, RewardPrompt = cpc.RewardPrompt, RewardCost = cpc.RewardCost });
+                                    return;
+                                case CommunityPointsChannelType.CustomRewardDeleted:
+                                    OnCustomRewardDeleted?.Invoke(this, new OnCustomRewardDeletedArgs { TimeStamp = cpc.TimeStamp, ChannelId = cpc.ChannelId, RewardId = cpc.RewardId, RewardTitle = cpc.RewardTitle, RewardPrompt = cpc.RewardPrompt });
                                     return;
                             }
                             return;


### PR DESCRIPTION
This pull request adds the forgotten channel reward deleted event.

```json
{
	"type": "custom-reward-deleted",
	"data": {
		"timestamp": "2019-12-26T23:30:50.054696516Z",
		"deleted_reward": {
			"id": "37bb2890-177f-4a5e-bb44-d6e777a8340e",
			"channel_id": "63937599",
			"title": "Does Nothing",
			"prompt": "This does nothing",
			"cost": 250,
			"is_user_input_required": true,
			"is_sub_only": false,
			"image": null,
			"default_image": {
				"url_1x": "https://static-cdn.jtvnw.net/custom-reward-images/default-1.png",
				"url_2x": "https://static-cdn.jtvnw.net/custom-reward-images/default-2.png",
				"url_4x": "https://static-cdn.jtvnw.net/custom-reward-images/default-4.png"
			},
			"background_color": "#6E0574",
			"is_enabled": false,
			"is_paused": false,
			"is_in_stock": true,
			"max_per_stream": {
				"is_enabled": false,
				"max_per_stream": 0
			},
			"should_redemptions_skip_request_queue": true
		}
	}
}
```