### PR TITLE
Handle commercial type to video playback.

### DIFF
--- a/TwitchLib.PubSub/Enums/VideoPlayback.cs
+++ b/TwitchLib.PubSub/Enums/VideoPlayback.cs
@@ -16,6 +16,10 @@
         /// <summary>
         /// On view count
         /// </summary>
-        ViewCount
+        ViewCount,
+        /// <summary>
+        /// On commercial
+        /// </summary>
+        Commercial
     }
 }

--- a/TwitchLib.PubSub/Events/OnCommercialArgs.cs
+++ b/TwitchLib.PubSub/Events/OnCommercialArgs.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace TwitchLib.PubSub.Events
+{
+    /// <inheritdoc/>
+    /// <summary>
+    /// Commercial arguments class.
+    /// </summary>
+    public class OnCommercialArgs : EventArgs
+    {
+        /// <summary>
+        /// The length of the commercial.
+        /// </summary>
+        public int Length;
+        /// <summary>
+        /// Server time issued by Twitch.
+        /// </summary>
+        public string ServerTime;
+    }
+}

--- a/TwitchLib.PubSub/Models/Responses/Messages/VideoPlayback.cs
+++ b/TwitchLib.PubSub/Models/Responses/Messages/VideoPlayback.cs
@@ -31,6 +31,11 @@ namespace TwitchLib.PubSub.Models.Responses.Messages
         /// </summary>
         /// <value>The viewers.</value>
         public int Viewers { get; }
+        /// <summary>
+        /// Gets the length.
+        /// </summary>
+        /// <value>The length.</value>
+        public int Length { get; }
 
         /// <summary>
         /// VideoPlayback constructor.
@@ -50,6 +55,9 @@ namespace TwitchLib.PubSub.Models.Responses.Messages
                 case "viewcount":
                     Type = VideoPlaybackType.ViewCount;
                     break;
+                case "commercial":
+                    Type = VideoPlaybackType.Commercial;
+                    break;
             }
             ServerTime = json.SelectToken("server_time")?.ToString();
             switch (Type)
@@ -61,6 +69,9 @@ namespace TwitchLib.PubSub.Models.Responses.Messages
                     Viewers = int.Parse(json.SelectToken("viewers").ToString());
                     break;
                 case VideoPlaybackType.StreamDown:
+                    break;
+                case VideoPlaybackType.Commercial:
+                    Length = int.Parse(json.SelectToken("length").ToString());
                     break;
             }
         }

--- a/TwitchLib.PubSub/TwitchPubSub.cs
+++ b/TwitchLib.PubSub/TwitchPubSub.cs
@@ -182,6 +182,11 @@ namespace TwitchLib.PubSub
         /// Fires when PubSub receives any data from Twitch
         /// </summary>
         public event EventHandler<OnLogArgs> OnLog;
+        /// <inheritdoc/>
+        /// <summary>
+        /// Fires when PubSub receives notice that the stream is playing a commercial.
+        /// </summary>
+        public event EventHandler<OnCommercialArgs> OnCommercial;
         #endregion
 
         /// <summary>
@@ -417,6 +422,9 @@ namespace TwitchLib.PubSub
                                     return;
                                 case VideoPlaybackType.ViewCount:
                                     OnViewCount?.Invoke(this, new OnViewCountArgs { ServerTime = vP.ServerTime, Viewers = vP.Viewers });
+                                    return;
+                                case VideoPlaybackType.Commercial:
+                                    OnCommercial?.Invoke(this, new OnCommercialArgs { ServerTime = vP.ServerTime, Length = vP.Length });
                                     return;
                             }
                             break;


### PR DESCRIPTION
When a video playback message of type commercial is received, the VideoPlayback message data treats it as an StreamUp message as that's the default and there is no type handling it in the type switch.

So I've added a "Commercial" video playback type, an OnCommercial event in the TwitchPubSub class and then wired it altogether.

To do so I had to modify the VideoPlayback class to have a Length property and then create an OnCommercialArgs class.