### PR TITLE
Update to CommunityPointsChannel and TwitchPubSub

### DIFF
--- a/TwitchLib.PubSub/Models/Responses/Messages/CommunityPointsChannel.cs
+++ b/TwitchLib.PubSub/Models/Responses/Messages/CommunityPointsChannel.cs
@@ -89,6 +89,11 @@ namespace TwitchLib.PubSub.Models.Responses.Messages
                 case "custom-reward-deleted":
                     Type = CommunityPointsChannelType.CustomRewardDeleted;
                     break;
+                default:                                    //Unknown type ignore.
+                case "redemption-status-update":            //Unimplemeted type - Used to singal change in state of RewardRedeemed.
+                case "update-redemption-statuses-progress": //Unimplemeted type - Used to single change in state of remain RewardRedeemed.
+                    Type = (CommunityPointsChannelType)(-1);
+                    break;
             }
 
             TimeStamp = DateTime.Parse(json.SelectToken("data.timestamp").ToString());

--- a/TwitchLib.PubSub/Models/Responses/Messages/CommunityPointsChannel.cs
+++ b/TwitchLib.PubSub/Models/Responses/Messages/CommunityPointsChannel.cs
@@ -91,7 +91,7 @@ namespace TwitchLib.PubSub.Models.Responses.Messages
                     break;
                 default:                                    //Unknown type ignore.
                 case "redemption-status-update":            //Unimplemeted type - Used to singal change in state of RewardRedeemed.
-                case "update-redemption-statuses-progress": //Unimplemeted type - Used to single change in state of remain RewardRedeemed.
+                case "update-redemption-statuses-progress": //Unimplemeted type - Used to single change in state of remaining RewardRedeemed.
                     Type = (CommunityPointsChannelType)(-1);
                     break;
             }

--- a/TwitchLib.PubSub/TwitchPubSub.cs
+++ b/TwitchLib.PubSub/TwitchPubSub.cs
@@ -578,6 +578,8 @@ namespace TwitchLib.PubSub
                 case "pong":
                     _pongRecivied = true; 
                     return;
+
+                case "reconnect": OnDisconnected(); break;
             }
             UnaccountedFor(message);
         }

--- a/TwitchLib.PubSub/TwitchPubSub.cs
+++ b/TwitchLib.PubSub/TwitchPubSub.cs
@@ -50,9 +50,9 @@ namespace TwitchLib.PubSub
         /// </summary>
         private readonly Timer _pongTimer = new Timer();
         /// <summary>
-        /// The pong recivied
+        /// The pong received
         /// </summary>
-        private bool _pongRecivied = false;
+        private bool _pongReceived = false;
         /// <summary>
         /// The topic list
         /// </summary>
@@ -321,7 +321,7 @@ namespace TwitchLib.PubSub
         private void PingTimerTick(object sender, ElapsedEventArgs e)
         {
             //Reset pong state.
-            _pongRecivied = false;
+            _pongReceived = false;
 
             //Send ping.
             var data = new JObject(
@@ -343,13 +343,14 @@ namespace TwitchLib.PubSub
             //Stop the pong timer.
             _pongTimer.Stop();
 
-            if (_pongRecivied)
+            if (_pongReceived)
             {
                 //If we recivied a pong we're good.
-                _pongRecivied = false;
+                _pongReceived = false;
             }
             else
             {
+                //Otherwise we're disconnected.
                 OnDisconnected();
             }
         }
@@ -574,11 +575,9 @@ namespace TwitchLib.PubSub
                             return;
                     }
                     break;
-
                 case "pong":
-                    _pongRecivied = true; 
+                    _pongReceived = true; 
                     return;
-
                 case "reconnect": OnDisconnected(); break;
             }
             UnaccountedFor(message);


### PR DESCRIPTION
1. Updates CommunityPointsChannel class to handle unknown message types in a graceful manner rather than throwing an exception when they won't parse as a RewardRedeemed message. 

2. Updates TwitchPubSub to:
a. Handle access to the _previousRequests in a thread safe manner.
b. Remove previous request from the _previousRequests when they are fulfilled. 
c. Implement a pong timer so that disconnections can be detected when no message is returned from a sent ping message.
d. Raise a disconnect event when a reconnect message is received to allow the consuming class to know the connection will be closed and needs to be re-opened.