### PR TITLE
add ChannelId to events that don't have it, where it's available

### DIFF
--- a/TwitchLib.PubSub/Events/OnCommercialArgs.cs
+++ b/TwitchLib.PubSub/Events/OnCommercialArgs.cs
@@ -16,5 +16,9 @@ namespace TwitchLib.PubSub.Events
         /// Server time issued by Twitch.
         /// </summary>
         public string ServerTime;
+        /// <summary>
+        /// Property representing the id of the channel the event originated from.
+        /// </summary>
+        public string ChannelId;
     }
 }

--- a/TwitchLib.PubSub/Events/OnListenResponseArgs.cs
+++ b/TwitchLib.PubSub/Events/OnListenResponseArgs.cs
@@ -21,5 +21,9 @@ namespace TwitchLib.PubSub.Events
         /// Property representing if request was successful.
         /// </summary>
         public bool Successful;
+        /// <summary>
+        /// Property representing the id of the channel the event originated from.
+        /// </summary>
+        public string ChannelId;
     }
 }

--- a/TwitchLib.PubSub/Events/OnStreamDownArgs.cs
+++ b/TwitchLib.PubSub/Events/OnStreamDownArgs.cs
@@ -12,5 +12,9 @@ namespace TwitchLib.PubSub.Events
         /// Property representing the server time of event.
         /// </summary>
         public string ServerTime;
+        /// <summary>
+        /// Property representing the id of the channel the event originated from.
+        /// </summary>
+        public string ChannelId;
     }
 }

--- a/TwitchLib.PubSub/Events/OnStreamUpArgs.cs
+++ b/TwitchLib.PubSub/Events/OnStreamUpArgs.cs
@@ -16,5 +16,9 @@ namespace TwitchLib.PubSub.Events
         /// Property representing play delay.
         /// </summary>
         public int PlayDelay;
+        /// <summary>
+        /// Property representing the id of the channel the event originated from.
+        /// </summary>
+        public string ChannelId;
     }
 }

--- a/TwitchLib.PubSub/Events/OnViewCountArgs.cs
+++ b/TwitchLib.PubSub/Events/OnViewCountArgs.cs
@@ -16,5 +16,9 @@ namespace TwitchLib.PubSub.Events
         /// Number of viewers at current time.
         /// </summary>
         public int Viewers;
+        /// <summary>
+        /// Property representing the id of the channel the event originated from.
+        /// </summary>
+        public string ChannelId;
     }
 }

--- a/TwitchLib.PubSub/TwitchPubSub.cs
+++ b/TwitchLib.PubSub/TwitchPubSub.cs
@@ -392,7 +392,8 @@ namespace TwitchLib.PubSub
                                 {
                                     //Remove the request.
                                     _previousRequests.RemoveAt(i);
-                                    OnListenResponse?.Invoke(this, new OnListenResponseArgs { Response = resp, Topic = request.Topic, Successful = resp.Successful });
+                                    _topicToChannelId.TryGetValue(request.Topic, out var requestChannelId);
+                                    OnListenResponse?.Invoke(this, new OnListenResponseArgs { Response = resp, Topic = request.Topic, Successful = resp.Successful, ChannelId = requestChannelId });
                                     handled = true;
                                 }
                                 else
@@ -529,16 +530,16 @@ namespace TwitchLib.PubSub
                             switch (vP?.Type)
                             {
                                 case VideoPlaybackType.StreamDown:
-                                    OnStreamDown?.Invoke(this, new OnStreamDownArgs { ServerTime = vP.ServerTime });
+                                    OnStreamDown?.Invoke(this, new OnStreamDownArgs { ServerTime = vP.ServerTime, ChannelId = channelId });
                                     return;
                                 case VideoPlaybackType.StreamUp:
-                                    OnStreamUp?.Invoke(this, new OnStreamUpArgs { PlayDelay = vP.PlayDelay, ServerTime = vP.ServerTime });
+                                    OnStreamUp?.Invoke(this, new OnStreamUpArgs { PlayDelay = vP.PlayDelay, ServerTime = vP.ServerTime, ChannelId = channelId });
                                     return;
                                 case VideoPlaybackType.ViewCount:
-                                    OnViewCount?.Invoke(this, new OnViewCountArgs { ServerTime = vP.ServerTime, Viewers = vP.Viewers });
+                                    OnViewCount?.Invoke(this, new OnViewCountArgs { ServerTime = vP.ServerTime, Viewers = vP.Viewers, ChannelId = channelId });
                                     return;
                                 case VideoPlaybackType.Commercial:
-                                    OnCommercial?.Invoke(this, new OnCommercialArgs { ServerTime = vP.ServerTime, Length = vP.Length });
+                                    OnCommercial?.Invoke(this, new OnCommercialArgs { ServerTime = vP.ServerTime, Length = vP.Length, ChannelId = channelId });
                                     return;
                             }
                             break;


### PR DESCRIPTION
We store a relationship between topic (with channel id included) and the channel id. We can use this dictionary to expose `ChannelId` in:
- `OnCommercial`
- `OnListenResponse`
- `OnStreamDown`
- `OnStreamUp`
- `OnViewCount`

This is useful for people that have the client connected to multiple channels.