### PR TITLE
Catch queued reward redemptions

### DIFF
--- a/TwitchLib.PubSub/Models/Responses/Messages/CommunityPointsChannel.cs
+++ b/TwitchLib.PubSub/Models/Responses/Messages/CommunityPointsChannel.cs
@@ -28,6 +28,11 @@ namespace TwitchLib.PubSub.Models.Responses.Messages
         /// <value>The channel identifier.</value>
         public string ChannelId { get; protected set; }
         /// <summary>
+        /// User id associated
+        /// </summary>
+        /// <value>The user id.</value>
+        public string UserId { get; protected set; }
+        /// <summary>
         /// Login value associated.
         /// </summary>
         /// <value>The login name.</value>
@@ -83,6 +88,7 @@ namespace TwitchLib.PubSub.Models.Responses.Messages
             switch (json.SelectToken("type").ToString())
             {
                 case "reward-redeemed":
+                case "redemption-status-update":
                     Type = CommunityPointsChannelType.RewardRedeemed;
                     break;
                 case "custom-reward-created":
@@ -95,7 +101,6 @@ namespace TwitchLib.PubSub.Models.Responses.Messages
                     Type = CommunityPointsChannelType.CustomRewardDeleted;
                     break;
                 default:                                    //Unknown type ignore.
-                case "redemption-status-update":            //Unimplemeted type - Used to singal change in state of RewardRedeemed.
                 case "update-redemption-statuses-progress": //Unimplemeted type - Used to single change in state of remaining RewardRedeemed.
                     Type = (CommunityPointsChannelType)(-1);
                     break;

--- a/TwitchLib.PubSub/Models/Responses/Messages/CommunityPointsChannel.cs
+++ b/TwitchLib.PubSub/Models/Responses/Messages/CommunityPointsChannel.cs
@@ -28,11 +28,6 @@ namespace TwitchLib.PubSub.Models.Responses.Messages
         /// <value>The channel identifier.</value>
         public string ChannelId { get; protected set; }
         /// <summary>
-        /// User id associated
-        /// </summary>
-        /// <value>The user id.</value>
-        public string UserId { get; protected set; }
-        /// <summary>
         /// Login value associated.
         /// </summary>
         /// <value>The login name.</value>

--- a/TwitchLib.PubSub/TwitchPubSub.cs
+++ b/TwitchLib.PubSub/TwitchPubSub.cs
@@ -800,7 +800,7 @@ namespace TwitchLib.PubSub
         /// Sends request to listen to rewards from specific channel.
         /// </summary>
         /// <param name="channelTwitchId">Channel to listen to rewards on.</param>
-        [ObsoleteAttribute("This method listens to an undocumented/retired/obsolete topic. Consider using ListenToChannelPoints()", false)]
+        [Obsolete("This method listens to an undocumented/retired/obsolete topic. Consider using ListenToChannelPoints()", false)]
         public void ListenToRewards(string channelTwitchId)
         {
             var topic = $"community-points-channel-v1.{channelTwitchId}";

--- a/TwitchLib.PubSub/TwitchPubSub.cs
+++ b/TwitchLib.PubSub/TwitchPubSub.cs
@@ -800,6 +800,7 @@ namespace TwitchLib.PubSub
         /// Sends request to listen to rewards from specific channel.
         /// </summary>
         /// <param name="channelTwitchId">Channel to listen to rewards on.</param>
+        [ObsoleteAttribute("This method listens to an undocumented/retired/obsolete topic. Consider using ListenToChannelPoints()", false)]
         public void ListenToRewards(string channelTwitchId)
         {
             var topic = $"community-points-channel-v1.{channelTwitchId}";


### PR DESCRIPTION
Right now, reward redemptions that are not executed immediately (ie they get queued up), and are instead handled later by a moderator/streamer are ignored by the PubSub client.  It's unclear initially why we had the code this way (maybe because of fluid models being returned from Twitch while this topic was undocumented). Now, we can safely use this same type for handling the `redemption-status-update` type.

Tested this code locally and it seems to be working fine.

Thanks to @itssimple for helping with this.

TODO: This whole topic (`community-points-channel-v1`) is deprecated/retired/undocumented in favor of the now documented `channel-points-channel-v1.<channel_id>`. We should probably keep the existing `community-points-channel-v1` topic so as to prevent breaking people's codebases unnecessarily. All new implementations should use the channel-points topic though (once implemented).

(squash this PR)