### PR TITLE
Listen to channel points v1 support

### DIFF
--- a/TwitchLib.PubSub/Enums/ChannelPointsChannelType.cs
+++ b/TwitchLib.PubSub/Enums/ChannelPointsChannelType.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.PubSub.Enums
+{
+    /// <summary>
+    /// Enum ChannelPointsChannelType
+    /// </summary>
+    public enum ChannelPointsChannelType
+    {
+        /// <summary>
+        /// Reward redeemed
+        /// </summary>
+        RewardRedeemed,
+        /// <summary>
+        /// Unknown
+        /// </summary>
+        Unknown
+    }
+}

--- a/TwitchLib.PubSub/Events/OnChannelPointsRewardRedeemedArgs.cs
+++ b/TwitchLib.PubSub/Events/OnChannelPointsRewardRedeemedArgs.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.PubSub.Events
+{
+    public class OnChannelPointsRewardRedeemedArgs
+    {
+        /// <summary>
+        /// The ID of the channel that this event fired from.
+        /// </summary>
+        public string ChannelId { get; internal set; }
+        /// <summary>
+        /// Details about the reward that was redeemed
+        /// </summary>
+        public Models.Responses.Messages.Redemption.RewardRedeemed RewardRedeemed { get; internal set; }
+    }
+}

--- a/TwitchLib.PubSub/Models/Responses/Message.cs
+++ b/TwitchLib.PubSub/Models/Responses/Message.cs
@@ -53,6 +53,9 @@ namespace TwitchLib.PubSub.Models.Responses
                 case "community-points-channel-v1":
                     MessageData = new CommunityPointsChannel(encodedJsonMessage);
                     break;
+                case "channel-points-channel-v1":
+                    MessageData = new ChannelPointsChannel(encodedJsonMessage);
+                    break;
                 case "leaderboard-events-v1":
                     MessageData = new LeaderboardEvents(encodedJsonMessage);
                     break;

--- a/TwitchLib.PubSub/Models/Responses/Messages/ChannelPointsChannel.cs
+++ b/TwitchLib.PubSub/Models/Responses/Messages/ChannelPointsChannel.cs
@@ -1,0 +1,42 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using TwitchLib.PubSub.Enums;
+using TwitchLib.PubSub.Models.Responses.Messages.Redemption;
+
+namespace TwitchLib.PubSub.Models.Responses.Messages
+{
+    /// <summary>
+    /// ChannelPointsChannel model constructor
+    /// Implements the <see cref="MessageData" />
+    /// </summary>
+    public class ChannelPointsChannel : MessageData
+    {
+        /// <summary>
+        /// Type of channel points channel
+        /// </summary>
+        public ChannelPointsChannelType Type { get; private set; }
+
+        public ChannelPointsData Data { get; private set; }
+
+        public string RawData { get; private set; }
+
+        public ChannelPointsChannel(string jsonStr)
+        {
+            RawData = jsonStr;
+            JToken json = JObject.Parse(jsonStr);
+            switch(json.SelectToken("type").ToString())
+            {
+                case "reward-redeemed":
+                    Type = ChannelPointsChannelType.RewardRedeemed;
+                    Data = JsonConvert.DeserializeObject<RewardRedeemed>(json.SelectToken("data").ToString());
+                    break;
+                default:
+                    Type = ChannelPointsChannelType.Unknown;
+                    break;
+            }
+        }
+    }
+}

--- a/TwitchLib.PubSub/Models/Responses/Messages/ChannelPointsData.cs
+++ b/TwitchLib.PubSub/Models/Responses/Messages/ChannelPointsData.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.PubSub.Models.Responses.Messages
+{
+    /// <summary>
+    /// Class representing channel points data
+    /// </summary>
+    public abstract class ChannelPointsData
+    {
+        //Leave empty for now
+    }
+}

--- a/TwitchLib.PubSub/Models/Responses/Messages/Redemption/DefaultImage.cs
+++ b/TwitchLib.PubSub/Models/Responses/Messages/Redemption/DefaultImage.cs
@@ -1,0 +1,17 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.PubSub.Models.Responses.Messages.Redemption
+{
+    public class DefaultImage
+    {
+        [JsonProperty(PropertyName = "url_1x")]
+        public string Url1x { get; protected set; }
+        [JsonProperty(PropertyName = "url_2x")]
+        public string Url2x { get; protected set; }
+        [JsonProperty(PropertyName = "url_4x")]
+        public string Url4x { get; protected set; }
+    }
+}

--- a/TwitchLib.PubSub/Models/Responses/Messages/Redemption/GlobalCooldown.cs
+++ b/TwitchLib.PubSub/Models/Responses/Messages/Redemption/GlobalCooldown.cs
@@ -1,0 +1,15 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.PubSub.Models.Responses.Messages.Redemption
+{
+    public class GlobalCooldown
+    {
+        [JsonProperty(PropertyName = "is_enabled")]
+        public string IsEnabled { get; protected set; }
+        [JsonProperty(PropertyName = "global_cooldown_seconds")]
+        public int GlobalCooldownSeconds { get; protected set; }
+    }
+}

--- a/TwitchLib.PubSub/Models/Responses/Messages/Redemption/MaxPerStream.cs
+++ b/TwitchLib.PubSub/Models/Responses/Messages/Redemption/MaxPerStream.cs
@@ -1,0 +1,15 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.PubSub.Models.Responses.Messages.Redemption
+{
+    public class MaxPerStream
+    {
+        [JsonProperty(PropertyName = "is_enabled")]
+        public bool IsEnabled { get; protected set; }
+        [JsonProperty(PropertyName = "max_per_stream")]
+        public int MaxPerStreamValue { get; protected set; }
+    }
+}

--- a/TwitchLib.PubSub/Models/Responses/Messages/Redemption/MaxPerUserPerStream.cs
+++ b/TwitchLib.PubSub/Models/Responses/Messages/Redemption/MaxPerUserPerStream.cs
@@ -1,0 +1,15 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.PubSub.Models.Responses.Messages.Redemption
+{
+    public class MaxPerUserPerStream
+    {
+        [JsonProperty(PropertyName = "is_enabled")]
+        public string IsEnabled { get; protected set; }
+        [JsonProperty(PropertyName = "max_per_user_per_stream")]
+        public int MaxPerUserPerStreamValue { get; protected set; }
+    }
+}

--- a/TwitchLib.PubSub/Models/Responses/Messages/Redemption/Redemption.cs
+++ b/TwitchLib.PubSub/Models/Responses/Messages/Redemption/Redemption.cs
@@ -1,0 +1,23 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.PubSub.Models.Responses.Messages.Redemption
+{
+    public class Redemption
+    {
+        [JsonProperty(PropertyName = "id")]
+        public string Id { get; protected set; }
+        [JsonProperty(PropertyName = "user")]
+        public User User { get; protected set; }
+        [JsonProperty(PropertyName = "channel_id")]
+        public string ChannelId { get; protected set; }
+        [JsonProperty(PropertyName = "redeemed_at")]
+        public DateTime RedeemedAt { get; protected set; }
+        [JsonProperty(PropertyName = "reward")]
+        public Reward Reward { get; protected set; }
+        [JsonProperty(PropertyName = "status")]
+        public string Status { get; protected set; }
+    }
+}

--- a/TwitchLib.PubSub/Models/Responses/Messages/Redemption/Reward.cs
+++ b/TwitchLib.PubSub/Models/Responses/Messages/Redemption/Reward.cs
@@ -1,0 +1,51 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.PubSub.Models.Responses.Messages.Redemption
+{
+    public class Reward
+    {
+        [JsonProperty(PropertyName = "id")]
+        public string Id { get; protected set; }
+        [JsonProperty(PropertyName = "channel_id")]
+        public string ChannelId { get; protected set; }
+        [JsonProperty(PropertyName = "title")]
+        public string Title { get; protected set; }
+        [JsonProperty(PropertyName = "prompt")]
+        public string Prompt { get; protected set; }
+        [JsonProperty(PropertyName = "cost")]
+        public int Cost { get; protected set; }
+        [JsonProperty(PropertyName = "is_user_input_required")]
+        public bool IsUserInputRequired { get; protected set; }
+        [JsonProperty(PropertyName = "is_sub_only")]
+        public bool IsSubOnly { get; protected set; }
+        [JsonProperty(PropertyName = "image")]
+        public string Image { get; protected set; }
+        [JsonProperty(PropertyName = "default_image")]
+        public DefaultImage DefaultImage { get; protected set; }
+        [JsonProperty(PropertyName = "background_color")]
+        public string BackgroundColor { get; protected set; }
+        [JsonProperty(PropertyName = "is_enabled")]
+        public bool IsEnabled { get; protected set; }
+        [JsonProperty(PropertyName = "is_paused")]
+        public bool IsPaused { get; protected set; }
+        [JsonProperty(PropertyName = "is_in_stock")]
+        public bool IsInStock { get; protected set; }
+        [JsonProperty(PropertyName = "max_per_stream")]
+        public MaxPerStream MaxPerStream { get; protected set; }
+        [JsonProperty(PropertyName = "should_redemptions_skip_request_queue")]
+        public bool ShouldRedemptionsSkipRequestQueue { get; protected set; }
+        [JsonProperty(PropertyName = "template_id")]
+        public string TemplateId { get; protected set; }
+        [JsonProperty(PropertyName = "updated_for_indicator_at")]
+        public DateTime UpdatedForIndicatorAt { get; protected set; }
+        [JsonProperty(PropertyName = "max_per_user_per_stream")]
+        public MaxPerUserPerStream MaxPerUserPerStream { get; protected set; }
+        [JsonProperty(PropertyName = "global_cooldown")]
+        public GlobalCooldown GlobalCooldown { get; protected set; }
+        [JsonProperty(PropertyName = "cooldown_expires_at")]
+        public DateTime? CooldownExpiresAt { get; protected set; }
+    }
+}

--- a/TwitchLib.PubSub/Models/Responses/Messages/Redemption/RewardRedeemed.cs
+++ b/TwitchLib.PubSub/Models/Responses/Messages/Redemption/RewardRedeemed.cs
@@ -1,0 +1,15 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.PubSub.Models.Responses.Messages.Redemption
+{
+    public class RewardRedeemed : ChannelPointsData
+    {
+        [JsonProperty(PropertyName = "timestamp")]
+        public DateTime Timestamp { get; protected set; }
+        [JsonProperty(PropertyName = "redemption")]
+        public Redemption Redemption { get; protected set; }
+    }
+}

--- a/TwitchLib.PubSub/Models/Responses/Messages/User.cs
+++ b/TwitchLib.PubSub/Models/Responses/Messages/User.cs
@@ -1,0 +1,17 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.PubSub.Models.Responses.Messages
+{
+    public class User
+    {
+        [JsonProperty(PropertyName = "id")]
+        public string Id { get; protected set; }
+        [JsonProperty(PropertyName = "login")]
+        public string Login { get; protected set; }
+        [JsonProperty(PropertyName = "display_name")]
+        public string DisplayName { get; protected set; }
+    }
+}


### PR DESCRIPTION
This adds a single method: `ListenToChannelPoints` and a new event: `OnChannelPointsRewardRedeemed`. 

This has been tested and is fully working.