### PR TITLE
support for automod-queue topic

### DIFF
--- a/TwitchLib.PubSub/Enums/AutomodQueueType.cs
+++ b/TwitchLib.PubSub/Enums/AutomodQueueType.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.PubSub.Enums
+{
+    /// <summary>
+    /// Enum ChannelPointsChannelType
+    /// </summary>
+    public enum AutomodQueueType
+    {
+        /// <summary>
+        /// Caught message update
+        /// </summary>
+        CaughtMessage,
+        /// <summary>
+        /// Unknown
+        /// </summary>
+        Unknown
+    }
+}

--- a/TwitchLib.PubSub/Events/OnAutomodCaughtMessageArgs.cs
+++ b/TwitchLib.PubSub/Events/OnAutomodCaughtMessageArgs.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using TwitchLib.PubSub.Models.Responses.Messages.AutomodCaughtMessage;
+
+namespace TwitchLib.PubSub.Events
+{
+    public class OnAutomodCaughtMessageArgs
+    {
+        /// <summary>
+        /// Details about the caught message
+        /// </summary>
+        public AutomodCaughtMessage AutomodCaughtMessage;
+        /// <summary>
+        /// The ID of the channel that this event fired from.
+        /// </summary>
+        public string ChannelId;
+    }
+}

--- a/TwitchLib.PubSub/Models/Responses/Message.cs
+++ b/TwitchLib.PubSub/Models/Responses/Message.cs
@@ -1,6 +1,7 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using TwitchLib.PubSub.Models.Responses.Messages;
+using TwitchLib.PubSub.Models.Responses.Messages.AutomodCaughtMessage;
 
 namespace TwitchLib.PubSub.Models.Responses
 {
@@ -30,6 +31,9 @@ namespace TwitchLib.PubSub.Models.Responses
             var encodedJsonMessage = json.SelectToken("message").ToString();
             switch (Topic?.Split('.')[0])
             {
+                case "automod-queue":
+                    MessageData = new AutomodQueue(encodedJsonMessage);
+                    break;
                 case "chat_moderator_actions":
                     MessageData = new ChatModeratorActions(encodedJsonMessage);
                     break;

--- a/TwitchLib.PubSub/Models/Responses/Messages/AutomodCaughtMessage/Automod.cs
+++ b/TwitchLib.PubSub/Models/Responses/Messages/AutomodCaughtMessage/Automod.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.PubSub.Models.Responses.Messages.AutomodCaughtMessage
+{
+    public class Automod
+    {
+        [JsonProperty(PropertyName = "topics")]
+        public Dictionary<string, int> Topics;
+    }
+}

--- a/TwitchLib.PubSub/Models/Responses/Messages/AutomodCaughtMessage/AutomodCaughtMessage.cs
+++ b/TwitchLib.PubSub/Models/Responses/Messages/AutomodCaughtMessage/AutomodCaughtMessage.cs
@@ -1,0 +1,30 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.PubSub.Models.Responses.Messages.AutomodCaughtMessage
+{
+    /// <summary>
+    /// Model representing the data in automod caught message
+    /// Implements the <see cref="MessageData" />
+    /// </summary>
+    /// <seealso cref="MessageData" />
+    /// <inheritdoc />
+    public class AutomodCaughtMessage : AutomodQueueData
+    {
+        [JsonProperty(PropertyName = "content_classification")]
+        public ContentClassification ContentClassification { get; protected set; }
+        [JsonProperty(PropertyName = "message")]
+        public Message Message { get; protected set; }
+        [JsonProperty(PropertyName = "reason_code")]
+        public string ReasonCode { get; protected set; }
+        [JsonProperty(PropertyName = "resolver_id")]
+        public string ResolverId { get; protected set; }
+        [JsonProperty(PropertyName = "resolver_login")]
+        public string ResolverLogin { get; protected set; }
+        [JsonProperty(PropertyName = "status")]
+        public string Status { get; protected set; }
+
+    }
+}

--- a/TwitchLib.PubSub/Models/Responses/Messages/AutomodCaughtMessage/Content.cs
+++ b/TwitchLib.PubSub/Models/Responses/Messages/AutomodCaughtMessage/Content.cs
@@ -1,0 +1,15 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.PubSub.Models.Responses.Messages.AutomodCaughtMessage
+{
+    public class Content
+    {
+        [JsonProperty(PropertyName = "text")]
+        public string Text;
+        [JsonProperty(PropertyName = "fragments")]
+        public Fragment[] Fragments;
+    }
+}

--- a/TwitchLib.PubSub/Models/Responses/Messages/AutomodCaughtMessage/ContentClassification.cs
+++ b/TwitchLib.PubSub/Models/Responses/Messages/AutomodCaughtMessage/ContentClassification.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.PubSub.Models.Responses.Messages.AutomodCaughtMessage
+{
+    public class ContentClassification
+    {
+        public string Category;
+        public int Level;
+    }
+}

--- a/TwitchLib.PubSub/Models/Responses/Messages/AutomodCaughtMessage/Fragment.cs
+++ b/TwitchLib.PubSub/Models/Responses/Messages/AutomodCaughtMessage/Fragment.cs
@@ -1,0 +1,15 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.PubSub.Models.Responses.Messages.AutomodCaughtMessage
+{
+    public class Fragment
+    {
+        [JsonProperty(PropertyName = "text")]
+        public string Text;
+        [JsonProperty(PropertyName = "automod")]
+        public Automod Automod;
+    }
+}

--- a/TwitchLib.PubSub/Models/Responses/Messages/AutomodCaughtMessage/Message.cs
+++ b/TwitchLib.PubSub/Models/Responses/Messages/AutomodCaughtMessage/Message.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.PubSub.Models.Responses.Messages.AutomodCaughtMessage
+{
+    public class Message
+    {
+        [JsonProperty(PropertyName = "content")]
+        public Content Content;
+        [JsonProperty(PropertyName = "id")]
+        public string Id;
+        [JsonProperty(PropertyName = "sender")]
+        public Sender Sender;
+        [JsonProperty(PropertyName = "sent_at")]
+        public DateTime SentAt;
+    }
+}

--- a/TwitchLib.PubSub/Models/Responses/Messages/AutomodCaughtMessage/Sender.cs
+++ b/TwitchLib.PubSub/Models/Responses/Messages/AutomodCaughtMessage/Sender.cs
@@ -1,0 +1,17 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.PubSub.Models.Responses.Messages.AutomodCaughtMessage
+{
+    public class Sender
+    {
+        [JsonProperty(PropertyName = "user_id")]
+        public string UserId;
+        [JsonProperty(PropertyName = "login")]
+        public string Login;
+        [JsonProperty(PropertyName = "display_name")]
+        public string DisplayName;
+    }
+}

--- a/TwitchLib.PubSub/Models/Responses/Messages/AutomodQueue.cs
+++ b/TwitchLib.PubSub/Models/Responses/Messages/AutomodQueue.cs
@@ -1,0 +1,41 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using TwitchLib.PubSub.Enums;
+
+namespace TwitchLib.PubSub.Models.Responses.Messages
+{
+    /// <summary>
+    /// ChannelPointsChannel model constructor
+    /// Implements the <see cref="MessageData" />
+    /// </summary>
+    public class AutomodQueue : MessageData
+    {
+        /// <summary>
+        /// Type of channel points channel
+        /// </summary>
+        public AutomodQueueType Type { get; private set; }
+
+        public AutomodQueueData Data { get; private set; }
+
+        public string RawData { get; private set; }
+
+        public AutomodQueue(string jsonStr)
+        {
+            RawData = jsonStr;
+            JToken json = JObject.Parse(jsonStr);
+            switch (json.SelectToken("type").ToString())
+            {
+                case "automod_caught_message":
+                    Type = AutomodQueueType.CaughtMessage;
+                    Data = JsonConvert.DeserializeObject<AutomodCaughtMessage.AutomodCaughtMessage>(json.SelectToken("data").ToString());
+                    break;
+                default:
+                    Type = AutomodQueueType.Unknown;
+                    break;
+            }
+        }
+    }
+}

--- a/TwitchLib.PubSub/Models/Responses/Messages/AutomodQueueData.cs
+++ b/TwitchLib.PubSub/Models/Responses/Messages/AutomodQueueData.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.PubSub.Models.Responses.Messages
+{
+    /// <summary>
+    /// Class representing automod queue actions
+    /// </summary>
+    public abstract class AutomodQueueData
+    {
+        //Leave empty for now
+    }
+}


### PR DESCRIPTION
The channel moderation topic is no longer reporting automod held messages. This means that currently there are no pubsub topics that expose this information.

This topic is not documented or published anywhere, but it is intended for third party consumption, and will likely get published at some point in the near future.

This code is tested and working.