### PR TITLE
support for user-moderation-notifications pubsub topic, as well as automod caught user messages

### DIFF
--- a/TwitchLib.PubSub/Enums/UserModerationNotificationsType.cs
+++ b/TwitchLib.PubSub/Enums/UserModerationNotificationsType.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.PubSub.Enums
+{
+    /// <summary>
+    /// Enum ChannelPointsChannelType
+    /// </summary>
+    public enum UserModerationNotificationsType
+    {
+        /// <summary>
+        /// Automod caught message
+        /// </summary>
+        AutomodCaughtMessage,
+        /// <summary>
+        /// Unknown
+        /// </summary>
+        Unknown
+    }
+}

--- a/TwitchLib.PubSub/Events/OnAutomodCaughtUserMessage.cs
+++ b/TwitchLib.PubSub/Events/OnAutomodCaughtUserMessage.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using TwitchLib.PubSub.Models.Responses.Messages.UserModerationNotifications;
+using TwitchLib.PubSub.Models.Responses.Messages.UserModerationNotificationsTypes;
+
+namespace TwitchLib.PubSub.Events
+{
+    public class OnAutomodCaughtUserMessage
+    {
+        /// <summary>
+        /// Details about the caught message
+        /// </summary>
+        public AutomodCaughtMessage AutomodCaughtMessage;
+        /// <summary>
+        /// The ID of the channel that this event fired from.
+        /// </summary>
+        public string ChannelId;
+        /// <summary>
+        /// The ID of the user that this event fired from.
+        /// </summary>
+        public string UserId;
+    }
+}

--- a/TwitchLib.PubSub/Models/Responses/Message.cs
+++ b/TwitchLib.PubSub/Models/Responses/Message.cs
@@ -2,6 +2,7 @@
 using Newtonsoft.Json.Linq;
 using TwitchLib.PubSub.Models.Responses.Messages;
 using TwitchLib.PubSub.Models.Responses.Messages.AutomodCaughtMessage;
+using TwitchLib.PubSub.Models.Responses.Messages.UserModerationNotifications;
 
 namespace TwitchLib.PubSub.Models.Responses
 {
@@ -31,6 +32,9 @@ namespace TwitchLib.PubSub.Models.Responses
             var encodedJsonMessage = json.SelectToken("message").ToString();
             switch (Topic?.Split('.')[0])
             {
+                case "user-moderation-notifications":
+                    MessageData = new UserModerationNotifications(encodedJsonMessage);
+                    break;
                 case "automod-queue":
                     MessageData = new AutomodQueue(encodedJsonMessage);
                     break;

--- a/TwitchLib.PubSub/Models/Responses/Messages/UserModerationNotifications.cs
+++ b/TwitchLib.PubSub/Models/Responses/Messages/UserModerationNotifications.cs
@@ -1,0 +1,37 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using TwitchLib.PubSub.Enums;
+
+namespace TwitchLib.PubSub.Models.Responses.Messages.UserModerationNotifications
+{
+    /// <summary>
+    /// userModerationNotifications model constructor
+    /// Implements the <see cref="MessageData" />
+    /// </summary>
+    public class UserModerationNotifications : MessageData
+    {
+        public UserModerationNotificationsType Type { get; private set; }
+        public UserModerationNotificationsData Data { get; private set; }
+
+        public string RawData { get; private set; }
+
+        public UserModerationNotifications(string jsonStr)
+        {
+            RawData = jsonStr;
+            JToken json = JObject.Parse(jsonStr);
+            switch (json.SelectToken("type").ToString())
+            {
+                case "automod_caught_message":
+                    Type = UserModerationNotificationsType.AutomodCaughtMessage;
+                    Data = JsonConvert.DeserializeObject<UserModerationNotificationsTypes.AutomodCaughtMessage>(json.SelectToken("data").ToString());
+                    break;
+                default:
+                    Type = UserModerationNotificationsType.Unknown;
+                    break;
+            }
+        }
+    }
+}

--- a/TwitchLib.PubSub/Models/Responses/Messages/UserModerationNotificationsData.cs
+++ b/TwitchLib.PubSub/Models/Responses/Messages/UserModerationNotificationsData.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.PubSub.Models.Responses.Messages
+{
+    /// <summary>
+    /// Class representing user moderation notifications
+    /// </summary>
+    public abstract class UserModerationNotificationsData
+    {
+        //Leave empty for now
+    }
+}

--- a/TwitchLib.PubSub/Models/Responses/Messages/UserModerationNotificationsTypes/AutomodCaughtMessage.cs
+++ b/TwitchLib.PubSub/Models/Responses/Messages/UserModerationNotificationsTypes/AutomodCaughtMessage.cs
@@ -1,0 +1,15 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.PubSub.Models.Responses.Messages.UserModerationNotificationsTypes
+{
+    public class AutomodCaughtMessage : UserModerationNotificationsData
+    {
+        [JsonProperty(PropertyName = "message_id")]
+        public string MessageId { get; protected set; }
+        [JsonProperty(PropertyName = "status")]
+        public string Status { get; protected set; }
+    }
+}

--- a/TwitchLib.PubSub/TwitchPubSub.cs
+++ b/TwitchLib.PubSub/TwitchPubSub.cs
@@ -812,8 +812,8 @@ namespace TwitchLib.PubSub
         /// <summary>
         /// Sends a request to listenOn timeouts and bans in a specific channel
         /// </summary>
-        /// <param name="myTwitchId">A moderator's twitch acount's ID (can be fetched from TwitchApi)</param>
-        /// <param name="channelTwitchId">Channel ID who has previous parameter's moderator (can be fetched from TwitchApi)</param>
+        /// <param name="userId">A moderator's twitch acount's ID (can be fetched from TwitchApi)</param>
+        /// <param name="channelId">Channel ID who has previous parameter's moderator (can be fetched from TwitchApi)</param>
         public void ListenToChatModeratorActions(string userId, string channelId)
         {
             var topic = $"chat_moderator_actions.{userId}.{channelId}";

--- a/TwitchLib.PubSub/TwitchPubSub.cs
+++ b/TwitchLib.PubSub/TwitchPubSub.cs
@@ -814,10 +814,10 @@ namespace TwitchLib.PubSub
         /// </summary>
         /// <param name="myTwitchId">A moderator's twitch acount's ID (can be fetched from TwitchApi)</param>
         /// <param name="channelTwitchId">Channel ID who has previous parameter's moderator (can be fetched from TwitchApi)</param>
-        public void ListenToChatModeratorActions(string myTwitchId, string channelTwitchId)
+        public void ListenToChatModeratorActions(string userId, string channelId)
         {
-            var topic = $"chat_moderator_actions.{myTwitchId}.{channelTwitchId}";
-            _topicToChannelId[topic] = channelTwitchId;
+            var topic = $"chat_moderator_actions.{userId}.{channelId}";
+            _topicToChannelId[topic] = channelId;
             ListenToTopic(topic);
         }
 


### PR DESCRIPTION
`user-moderation-notifications` is a topic that will include a number of moderation notifications for an individual user. Currently, only notifications for when automod holds a user's message is implemented.

This topic is currently undocumented, but is intended for third party consumption. We can expect proper documentation for this soonish.

This is tested.