### PR TITLE
Added UserInput to the Redemption model

### DIFF
--- a/TwitchLib.PubSub/Models/Responses/Messages/Redemption/Redemption.cs
+++ b/TwitchLib.PubSub/Models/Responses/Messages/Redemption/Redemption.cs
@@ -17,6 +17,8 @@ namespace TwitchLib.PubSub.Models.Responses.Messages.Redemption
         public DateTime RedeemedAt { get; protected set; }
         [JsonProperty(PropertyName = "reward")]
         public Reward Reward { get; protected set; }
+        [JsonProperty(PropertyName = "user_input")]
+        public string UserInput { get; protected set; }
         [JsonProperty(PropertyName = "status")]
         public string Status { get; protected set; }
     }


### PR DESCRIPTION
Currently there's no way to get the user input from redeems which accept it. This PR adds that property to the model.

If user input is not required, the value will be null.

Tested with rewards which require and don't require user input.