### PR TITLE
Fix Redemption image parsing exception

### DIFF
--- a/TwitchLib.PubSub/Models/Responses/Messages/Redemption/RedemptionImage.cs
+++ b/TwitchLib.PubSub/Models/Responses/Messages/Redemption/RedemptionImage.cs
@@ -1,11 +1,8 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace TwitchLib.PubSub.Models.Responses.Messages.Redemption
 {
-    public class DefaultImage
+    public class RedemptionImage
     {
         [JsonProperty(PropertyName = "url_1x")]
         public string Url1x { get; protected set; }

--- a/TwitchLib.PubSub/Models/Responses/Messages/Redemption/Reward.cs
+++ b/TwitchLib.PubSub/Models/Responses/Messages/Redemption/Reward.cs
@@ -1,7 +1,5 @@
 ﻿using Newtonsoft.Json;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace TwitchLib.PubSub.Models.Responses.Messages.Redemption
 {
@@ -24,7 +22,7 @@ namespace TwitchLib.PubSub.Models.Responses.Messages.Redemption
         [JsonProperty(PropertyName = "image")]
         public string Image { get; protected set; }
         [JsonProperty(PropertyName = "default_image")]
-        public DefaultImage DefaultImage { get; protected set; }
+        public RedemptionImage DefaultImage { get; protected set; }
         [JsonProperty(PropertyName = "background_color")]
         public string BackgroundColor { get; protected set; }
         [JsonProperty(PropertyName = "is_enabled")]

--- a/TwitchLib.PubSub/Models/Responses/Messages/Redemption/Reward.cs
+++ b/TwitchLib.PubSub/Models/Responses/Messages/Redemption/Reward.cs
@@ -20,7 +20,7 @@ namespace TwitchLib.PubSub.Models.Responses.Messages.Redemption
         [JsonProperty(PropertyName = "is_sub_only")]
         public bool IsSubOnly { get; protected set; }
         [JsonProperty(PropertyName = "image")]
-        public string Image { get; protected set; }
+        public RedemptionImage Image { get; protected set; }
         [JsonProperty(PropertyName = "default_image")]
         public RedemptionImage DefaultImage { get; protected set; }
         [JsonProperty(PropertyName = "background_color")]


### PR DESCRIPTION
This PR fixes the parsing exception occuring when parsing a channel points reward with a set image