### PR TITLE
Bring nuget packages up to date and to the same versions as API and Client

### DIFF
--- a/TwitchLib.PubSub/TwitchLib.PubSub.csproj
+++ b/TwitchLib.PubSub/TwitchLib.PubSub.csproj
@@ -22,8 +22,8 @@
     <FileVersion>3.2.3</FileVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
     <PackageReference Include="TwitchLib.Communication" Version="1.0.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Currently Pubsub has outdated nuget packages that differ from the ones used in Api and Client and therefore could lead package version conflicts.
This PR updates packages used for pubsub and brings them to the same versions as used in Api and Client to mitigate that possible issues