### PR TITLE
Add support for raid_cancel_v2 event

### DIFF
--- a/TwitchLib.PubSub/Enums/RaidType.cs
+++ b/TwitchLib.PubSub/Enums/RaidType.cs
@@ -20,6 +20,10 @@
         /// <summary>
         /// When the raid actually starts
         /// </summary>
-        RaidGo
+        RaidGo,
+        /// <summary>
+        /// When the raid is cancelled
+        /// </summary>
+        RaidCancel
     }
 }

--- a/TwitchLib.PubSub/Events/OnRaidCancelArgs.cs
+++ b/TwitchLib.PubSub/Events/OnRaidCancelArgs.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace TwitchLib.PubSub.Events {
+    /// <inheritdoc />
+    /// <summary>
+    /// Object representing the arguments for a raid cancel event
+    /// </summary>
+    public class OnRaidCancelArgs: EventArgs {
+        /// <summary>
+        /// The channel ID the event came from
+        /// </summary>
+        public string ChannelId;
+        /// <summary>
+        /// Property representing the id of the raid event
+        /// </summary>
+        public Guid Id;
+        /// <summary>
+        /// Property representing the target channel id
+        /// </summary>
+        public string TargetChannelId;
+        /// <summary>
+        /// Property representing the target channel login
+        /// </summary>
+        public string TargetLogin;
+        /// <summary>
+        /// Property representing  the target display name
+        /// </summary>
+        public string TargetDisplayName;
+        /// <summary>
+        /// Property representing the target profile image url
+        /// </summary>
+        public string TargetProfileImage;
+        /// <summary>
+        /// Property representing the count of people in the raid
+        /// </summary>
+        public int ViewerCount;
+    }
+}

--- a/TwitchLib.PubSub/Models/Responses/Messages/RaidEvents.cs
+++ b/TwitchLib.PubSub/Models/Responses/Messages/RaidEvents.cs
@@ -86,6 +86,9 @@ namespace TwitchLib.PubSub.Models.Responses.Messages
                 case "raid_go_v2":
                     Type = RaidType.RaidGo;
                     break;
+                case "raid_cancel_v2":
+                    Type = RaidType.RaidCancel;
+                    break;
 
             }
 
@@ -110,6 +113,15 @@ namespace TwitchLib.PubSub.Models.Responses.Messages
                     ViewerCount = int.Parse(json.SelectToken("raid.viewer_count").ToString());
                     break;
                 case RaidType.RaidGo:
+                    Id = Guid.Parse(json.SelectToken("raid.id").ToString());
+                    ChannelId = json.SelectToken("raid.source_id").ToString();
+                    TargetChannelId = json.SelectToken("raid.target_id").ToString();
+                    TargetLogin = json.SelectToken("raid.target_login").ToString();
+                    TargetDisplayName = json.SelectToken("raid.target_display_name").ToString();
+                    TargetProfileImage = json.SelectToken("raid.target_profile_image").ToString();
+                    ViewerCount = int.Parse(json.SelectToken("raid.viewer_count").ToString());
+                    break;
+                case RaidType.RaidCancel:
                     Id = Guid.Parse(json.SelectToken("raid.id").ToString());
                     ChannelId = json.SelectToken("raid.source_id").ToString();
                     TargetChannelId = json.SelectToken("raid.target_id").ToString();

--- a/TwitchLib.PubSub/TwitchPubSub.cs
+++ b/TwitchLib.PubSub/TwitchPubSub.cs
@@ -250,6 +250,11 @@ namespace TwitchLib.PubSub
         public event EventHandler<OnRaidGoArgs> OnRaidGo;
         /// <inheritdoc />
         /// <summary>
+        /// Fires when PubSub receives notice when a channel cancels the raid
+        /// </summary>
+        public event EventHandler<OnRaidCancelArgs> OnRaidCancel; 
+        /// <inheritdoc />
+        /// <summary>
         /// Fires when PubSub receives any data from Twitch
         /// </summary>
         public event EventHandler<OnLogArgs> OnLog;
@@ -646,6 +651,9 @@ namespace TwitchLib.PubSub
                                     return;
                                 case RaidType.RaidGo:
                                     OnRaidGo?.Invoke(this, new OnRaidGoArgs { Id = r.Id, ChannelId = r.ChannelId, TargetChannelId = r.TargetChannelId, TargetLogin = r.TargetLogin, TargetDisplayName = r.TargetDisplayName, TargetProfileImage = r.TargetProfileImage, ViewerCount = r.ViewerCount });
+                                    return;
+                                case RaidType.RaidCancel:
+                                    OnRaidCancel?.Invoke(this, new OnRaidCancelArgs() { Id = r.Id, ChannelId = r.ChannelId, TargetChannelId = r.TargetChannelId, TargetLogin = r.TargetLogin, TargetDisplayName = r.TargetDisplayName, TargetProfileImage = r.TargetProfileImage, ViewerCount = r.ViewerCount });
                                     return;
                             }
                             return;


### PR DESCRIPTION
Hi, this is a fix for issue #110 which I filed a while ago. I've tested in my own project and it seems to work just fine (fixing the issue of PubSub breaking when this event was trigged). I've modelled the event on the `OnRaidGo` event as they contain pretty much identical data in the actual message.

I've included the raw message Twitch sends below in case you want to reference it. Please let me know if there are any changes or improvements you'd need me to make

```
{"type":"MESSAGE","data":{"topic":"raid.23678658","message":"{\"type\":\"raid_cancel_v2\",\"raid\":{\"id\":\"1d1fed75-4015-41d3-80c7-6d390220f3f4\",\"creator_id\":\"23678658\",\"source_id\":\"23678658\",\"target_id\":\"835434545\",\"target_login\":\"ladyvignette\",\"target_display_name\":\"LadyVignette\",\"target_profile_image\":\"https://static-cdn.jtvnw.net/jtv_user_pictures/09ed28e3-d790-491c-92c6-cd619fd0ad85-profile_image-%s.png\",\"transition_jitter_seconds\":0,\"force_raid_now_seconds\":90,\"viewer_count\":6}}"}}
```