### PR TITLE
fix: Missing events in ITwitchPubSub

### DIFF
--- a/TwitchLib.PubSub/Interfaces/ITwitchPubSub.cs
+++ b/TwitchLib.PubSub/Interfaces/ITwitchPubSub.cs
@@ -16,6 +16,11 @@ namespace TwitchLib.PubSub.Interfaces
         /// Occurs when [on bits received].
         /// </summary>
         event EventHandler<OnBitsReceivedArgs> OnBitsReceived;
+        /// <inheritdoc />
+        /// <summary>
+        /// Occurs when [on bits received v2].
+        /// </summary>
+        event EventHandler<OnBitsReceivedV2Args> OnBitsReceivedV2;
         /// <summary>
         /// Occurs when [on channel extension broadcast].
         /// </summary>
@@ -164,6 +169,14 @@ namespace TwitchLib.PubSub.Interfaces
         /// Occurs when [on prediction].
         /// </summary>
         event EventHandler<OnPredictionArgs> OnPrediction;
+        /// <summary>
+        ///Occurs when [on automod caught message].
+        /// </summary>
+        event EventHandler<OnAutomodCaughtMessageArgs> OnAutomodCaughtMessage;
+        /// <summary>
+        /// Occurs when [on automod caught user message].
+        /// </summary>
+        event EventHandler<OnAutomodCaughtUserMessage> OnAutomodCaughtUserMessage;
 
         /// <summary>
         /// Connects this instance.


### PR DESCRIPTION
Add back some declarations of events from `TwitchPubSub` to `ITwitchPubSub`